### PR TITLE
feat: Integrate Dragonbane starter data via Pinia store

### DIFF
--- a/dragonbane-char-gen/package-lock.json
+++ b/dragonbane-char-gen/package-lock.json
@@ -8,6 +8,7 @@
       "name": "dragonbane-char-gen",
       "version": "0.0.0",
       "dependencies": {
+        "pinia": "^3.0.3",
         "vue": "^3.5.17"
       },
       "devDependencies": {
@@ -1422,6 +1423,15 @@
         "@vue/shared": "3.5.17"
       }
     },
+    "node_modules/@vue/devtools-api": {
+      "version": "7.7.7",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-7.7.7.tgz",
+      "integrity": "sha512-lwOnNBH2e7x1fIIbVT7yF5D+YWhqELm55/4ZKf45R9T8r9dE2AIOy8HKjfqzGsoTHFbWbr337O4E0A0QADnjBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-kit": "^7.7.7"
+      }
+    },
     "node_modules/@vue/devtools-core": {
       "version": "7.7.7",
       "resolved": "https://registry.npmjs.org/@vue/devtools-core/-/devtools-core-7.7.7.tgz",
@@ -1463,7 +1473,6 @@
       "version": "7.7.7",
       "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-7.7.7.tgz",
       "integrity": "sha512-wgoZtxcTta65cnZ1Q6MbAfePVFxfM+gq0saaeytoph7nEa7yMXoi6sCPy4ufO111B9msnw0VOWjPEFCXuAKRHA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@vue/devtools-shared": "^7.7.7",
@@ -1479,7 +1488,6 @@
       "version": "7.7.7",
       "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-7.7.7.tgz",
       "integrity": "sha512-+udSj47aRl5aKb0memBvcUG9koarqnxNM5yjuREvqwK6T3ap4mn3Zqqc17QrBFTqSMjr3HK1cvStEZpMDpfdyw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "rfdc": "^1.4.1"
@@ -1539,7 +1547,6 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/birpc/-/birpc-2.4.0.tgz",
       "integrity": "sha512-5IdNxTyhXHv2UlgnPHQ0h+5ypVmkrYHzL8QT+DwFZ//2N/oNV8Ch+BCRmTJ3x6/z9Axo/cXYBc9eprsUVK/Jsg==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/antfu"
@@ -1626,7 +1633,6 @@
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-3.0.5.tgz",
       "integrity": "sha512-yCEafptTtb4bk7GLEQoM8KVJpxAfdBJYaXyzQEgQQQgYrZiDp8SJmGKlYza6CYjEDNstAdNdKA3UuoULlEbS6w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-what": "^4.1.8"
@@ -1932,7 +1938,6 @@
       "version": "5.5.3",
       "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
       "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/human-signals": {
@@ -2023,7 +2028,6 @@
       "version": "4.1.16",
       "resolved": "https://registry.npmjs.org/is-what/-/is-what-4.1.16.tgz",
       "integrity": "sha512-ZhMwEosbFJkA0YhFnNDgTM4ZxDRsS6HqTo7qsZM08fehyRYIYa0yHu5R6mgo1n/8MgaPBXiPimPD77baVFYg+A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.13"
@@ -2131,7 +2135,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
       "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/mrmime": {
@@ -2259,7 +2262,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
       "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/picocolors": {
@@ -2279,6 +2281,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pinia": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/pinia/-/pinia-3.0.3.tgz",
+      "integrity": "sha512-ttXO/InUULUXkMHpTdp9Fj4hLpD/2AoJdmAbAeW2yu1iy1k+pkFekQXw5VpC0/5p51IOR/jDaDRfRWRnMMsGOA==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-api": "^7.7.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/posva"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.4.4",
+        "vue": "^2.7.0 || ^3.5.11"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/postcss": {
@@ -2329,7 +2352,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
       "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/rollup": {
@@ -2459,7 +2481,6 @@
       "version": "14.0.1",
       "resolved": "https://registry.npmjs.org/speakingurl/-/speakingurl-14.0.1.tgz",
       "integrity": "sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -2482,7 +2503,6 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/superjson/-/superjson-2.2.2.tgz",
       "integrity": "sha512-5JRxVqC8I8NuOUjzBbvVJAKNM8qoVuH0O77h4WInc/qC2q5IreqKxYwgkga3PfA22OayK2ikceb/B26dztPl+Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "copy-anything": "^3.0.2"

--- a/dragonbane-char-gen/package.json
+++ b/dragonbane-char-gen/package.json
@@ -9,6 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "pinia": "^3.0.3",
     "vue": "^3.5.17"
   },
   "devDependencies": {

--- a/dragonbane-char-gen/src/data/attributes.json
+++ b/dragonbane-char-gen/src/data/attributes.json
@@ -1,0 +1,32 @@
+[
+  {
+    "name": "Strength",
+    "abbreviation": "STR",
+    "description": "Raw muscle power."
+  },
+  {
+    "name": "Constitution",
+    "abbreviation": "CON",
+    "description": "Physical fitness and resilience."
+  },
+  {
+    "name": "Agility",
+    "abbreviation": "AGL",
+    "description": "Body control, speed, and fine motor skills."
+  },
+  {
+    "name": "Intelligence",
+    "abbreviation": "INT",
+    "description": "Mental acuity, intellect, and reasoning skills."
+  },
+  {
+    "name": "Willpower",
+    "abbreviation": "WIL",
+    "description": "Self-discipline and focus."
+  },
+  {
+    "name": "Charisma",
+    "abbreviation": "CHA",
+    "description": "Force of personality and empathy."
+  }
+]

--- a/dragonbane-char-gen/src/data/gear.json
+++ b/dragonbane-char-gen/src/data/gear.json
@@ -1,0 +1,201 @@
+{
+  "note": "This data is extracted from the Dragonbane Quickstart PDF. Full gear lists and details are likely in the core rulebook.",
+  "encumbrance_rules": {
+    "limit": "Half your STR (rounded up) items in Inventory without difficulty.",
+    "weapons_at_hand": "Up to three weapons at hand (worn on belt or readily available). Recorded under Weapons, do not count toward encumbrance. Shields count as weapons here.",
+    "helmet_armor": "Worn helmet & armor do not count toward encumbrance.",
+    "food": "Up to four rations of food count as one item.",
+    "torches_lanterns": "A torch, lamp, or lantern is an item. Lamps/lanterns can be refilled with lamp oil.",
+    "arrows_slingstones": "Quiver of arrows counts as a single item. Slingstones do not need to be noted down.",
+    "heavy_items": "Count as 2, 3, or more normal items (weight 2, 3, 4+). Take up rows equal to weight in inventory.",
+    "tiny_items": "Small, light items hidden in a closed fist. Do not affect encumbrance. Recorded in own section.",
+    "coins_encumbrance": "Single coins are tiny. <100: no encumbrance. 100-199: 1 item. 200-299: 2 items, etc.",
+    "over_encumbered": "Can temporarily carry more. Make STR roll to move in combat or walk for a shift. Failure: drop items or stay put.",
+    "carrying_others": "Automatically over-encumbered, cannot fight in combat."
+  },
+  "coins": {
+    "copper": "Used for smaller transactions.",
+    "silver": "Monetary transactions generally made with silver. 1 silver = 10 copper.",
+    "gold": "Used for larger transactions. 1 gold = 10 silver."
+  },
+  "weapons": [
+    {
+      "name": "Staff",
+      "grip": "2h",
+      "range": "2m",
+      "damage": "D8",
+      "durability": 9,
+      "features": ["Bludgeoning"],
+      "skill": "Staves",
+      "character_example": "Archmaster Aodhan"
+    },
+    {
+      "name": "Longbow",
+      "grip": "2h",
+      "range": "100m",
+      "damage": "D12",
+      "durability": 6,
+      "features": ["Piercing"],
+      "skill": "Bows",
+      "character_example": "Orla Moonsilver"
+    },
+    {
+      "name": "Knife",
+      "grip": "1h",
+      "range": " melee / 8m throwing (assumed from pre-gen, range not specified for throwing in main text but skill is Knives)",
+      "damage": "D8",
+      "durability": 6,
+      "features": ["Subtle", "Piercing"],
+      "skill": "Knives",
+      "character_example": "Orla Moonsilver (also Krisanna the Bold)"
+    },
+    {
+      "name": "Battleaxe",
+      "grip": "1h",
+      "range": "2m",
+      "damage": "2D8",
+      "durability": 9,
+      "features": ["Slashing"],
+      "skill": "Axes",
+      "character_example": "Makander of Halfbay"
+    },
+    {
+      "name": "Short Sword",
+      "grip": "1h",
+      "range": "2m",
+      "damage": "D10",
+      "durability": 12,
+      "features": ["Slashing", "Piercing"],
+      "skill": "Swords",
+      "character_example": "Makander of Halfbay (also Grub the Goblin)"
+    },
+    {
+      "name": "Small Shield",
+      "grip": "1h",
+      "range": "N/A (used for parrying)",
+      "damage": "D8 (parry value? Text says 'damage D8', durability 15 on sheet)",
+      "durability": 15,
+      "features": ["Bludgeoning (if used as weapon?)"],
+      "skill": "Any STR-based melee skill for parrying",
+      "character_example": "Makander of Halfbay"
+    },
+    {
+      "name": "Dagger",
+      "grip": "1h",
+      "range": " melee / 8m throwing (assumed from Krisanna's sheet, like Knife)",
+      "damage": "D8",
+      "durability": 9,
+      "features": ["Subtle", "Piercing", "Slashing"],
+      "skill": "Knives",
+      "character_example": "Krisanna the Bold"
+    },
+    {
+      "name": "Long Spear",
+      "grip": "2h",
+      "range": "4m",
+      "damage": "2D8",
+      "durability": 9,
+      "features": ["Long", "Piercing"],
+      "skill": "Spears",
+      "character_example": "Bastonn Bloodjaw (also Mummified Guards)"
+    },
+    {
+      "name": "Short Spear",
+      "grip": "1h",
+      "range": " melee / 36m throwing (range from Bastonn's sheet)",
+      "damage": "D10",
+      "durability": 9,
+      "features": ["Piercing"],
+      "skill": "Spears",
+      "character_example": "Bastonn Bloodjaw"
+    },
+    {
+      "name": "Shortbow",
+      "grip": "2h",
+      "range": "Not specified, assume less than Longbow",
+      "damage": "D10",
+      "durability": "Not specified",
+      "features": ["Piercing"],
+      "skill": "Bows",
+      "character_example": "Grub the Goblin"
+    },
+    {
+      "name": "Goblin Poison Dagger",
+      "grip": "1h",
+      "range": "melee",
+      "damage": "Not specified (assume D8 like other daggers)",
+      "durability": "Not specified",
+      "features": ["Piercing", "Slashing", "Coated with lethal viper venom (potency 9)"],
+      "skill": "Knives",
+      "found_in_adventure": "Riddermound - Antechamber"
+    },
+    {
+      "name": "Fiendcrusher (Light Warhammer)",
+      "grip": "Not specified (assume 1h or 1h/2h)",
+      "range": "melee",
+      "damage": "2D6",
+      "durability": 15,
+      "features": ["Magical: Glows red when bearer is within 10 meters of a demon", "Set with jewels"],
+      "skill": "Hammers",
+      "found_in_adventure": "Riddermound - The Lady's Hall"
+    }
+  ],
+  "armor": [
+    {
+      "name": "Leather Armor",
+      "armor_rating": 1,
+      "bane_on": ["SNEAKING (Makander's sheet has N/A, Krisanna's sheet has SNEAKING)"],
+      "notes": "+2 armor rating vs bludgeoning damage (optional rule).",
+      "character_example": "Orla Moonsilver, Krisanna the Bold, Grub the Goblin"
+    },
+    {
+      "name": "Plate Armor",
+      "armor_rating": 6,
+      "bane_on": ["SNEAKING", "ACROBATICS", "EVADE (Makander's sheet indicates these)"],
+      "notes": "No specific bonus vs damage types mentioned for plate.",
+      "character_example": "Makander of Halfbay"
+    },
+    {
+      "name": "Studded Leather Armor",
+      "armor_rating": 2,
+      "bane_on": ["SNEAKING (Bastonn's sheet)"],
+      "notes": "+2 armor rating vs bludgeoning damage (optional rule).",
+      "character_example": "Bastonn Bloodjaw"
+    },
+    {
+      "name": "Chainmail (Gilded)",
+      "armor_rating": 4,
+      "bane_on": ["SNEAKING"],
+      "notes": "Light and flexible. +2 armor rating vs slashing damage (optional rule).",
+      "found_in_adventure": "Riddermound - The Lady's Hall (on the Lady)"
+    },
+    {
+      "name": "Chainmail (Rusted)",
+      "armor_rating": "Crumbles if touched",
+      "bane_on": [],
+      "notes": "",
+      "found_in_adventure": "Riddermound - Guardhouse (on Mummified Guards)"
+    }
+  ],
+  "helmets": {
+    "general_rule": "Can be combined with armor to further increase armor rating. Equipping/unequipping is an action. Can give bane on certain skills. None of the pre-gen characters list a helmet.",
+    "demon_crown": {
+       "name": "Demon Crown (Gilded Crown)",
+       "armor_rating": "Not specified as AR, but has protective effect.",
+       "effect": "Imbued with a spell which halves all damage from attacks by demons (rounding up). Runes explain effect (LANGUAGES roll).",
+       "found_in_adventure": "Riddermound - Tomb of the Dragon Knight"
+    }
+  },
+  "general_items": [
+    { "name": "Spellbook", "character_example": "Archmaster Aodhan" },
+    { "name": "Torch", "character_example": "Multiple pre-gens" },
+    { "name": "Rope", "character_example": "Orla Moonsilver, Krisanna the Bold" },
+    { "name": "Lockpicks", "character_example": "Krisanna the Bold" },
+    { "name": "Quiver", "character_example": "Orla Moonsilver" },
+    { "name": "Flint & Tinder", "category": "Tiny Item", "character_example": "Multiple pre-gens" },
+    { "name": "Bandages", "mentioned_for": "HEALING skill (bane if not used)"},
+    { "name": "Antidote", "mentioned_for": "Poison effects"},
+    { "name": "Blanket", "mentioned_for": "Resisting Cold (bane if not used)"},
+    { "name": "Fur", "mentioned_for": "Resisting Cold (boon if used)"}
+  ]
+}

--- a/dragonbane-char-gen/src/data/heroic_abilities.json
+++ b/dragonbane-char-gen/src/data/heroic_abilities.json
@@ -1,0 +1,52 @@
+{
+  "note": "Heroic abilities are special abilities that give specific advantages. Pre-generated characters have one each, except mages who wield magic. This list is based on the pre-gen characters in the Quickstart.",
+  "abilities": [
+    {
+      "name": "Adaptive",
+      "character_example": "Archmaster Aodhan (Mage - uses Magic instead, but this is listed as his heroic ability textually)",
+      "cost_wp": 3,
+      "effect": "When rolling for a skill, you can choose to make the roll using another skill of your choice. You must be able to justify how you use the selected skill instead of the normal one. The GM has the final word, but should be lenient."
+    },
+    {
+      "name": "Twin Shot",
+      "character_example": "Orla Moonsilver",
+      "cost_wp": 3,
+      "effect": "By activating this ability when attacking with a bow, you shoot two arrows instead of one. Roll just once to hit, with a bane. Damage is rolled separately. The arrows can be directed at the same target or two different targets."
+    },
+    {
+      "name": "Guardian",
+      "character_example": "Makander of Halfbay",
+      "cost_wp": 2,
+      "effect": "You do not hesitate to take a hit to protect your friends. If you and another player character are both within 2 meters of the same enemy and the enemy tries to attack the other character, you can activate this ability to force the enemy to attack you instead. Using this ability can be done out of turn and it does not count as an action."
+    },
+    {
+      "name": "Hard to Catch",
+      "character_example": "Krisanna the Bold (This is also listed as a Halfling innate ability, but presented as her Heroic Ability on her sheet)",
+      "cost_wp": 3,
+      "effect": "You can activate this ability when dodging an attack, getting a boon to the EVADE roll."
+    },
+    {
+      "name": "Backstabbing",
+      "character_example": "Krisanna the Bold",
+      "cost_wp": 3,
+      "effect": "You can activate this ability when making a melee attack against an enemy that is also within 2 meters of another player character. Your attack then counts as a sneak attack, which means it cannot be dodged or parried, you get a boon to the roll, and the number of dice rolled for the damage is increased by one (i.e. 2D8 instead of D8). This ability can only be used with a subtle weapon. Activating this ability does not count as an action."
+    },
+    {
+      "name": "Hunting Instincts",
+      "character_example": "Bastonn Bloodjaw (This is also listed as a Wolfkin innate ability, but presented as his Heroic Ability on his sheet)",
+      "cost_wp": 3,
+      "effect": "You can use this ability to designate a creature in sight, or a creature you can catch the scent of, as your prey. This counts as an action in combat. You can follow the scent of your prey for a full day, and you can spend 1 further WP (not an action) to gain a boon for an attack against your prey."
+    },
+    {
+      "name": "Veteran",
+      "character_example": "Bastonn Bloodjaw",
+      "cost_wp": 1,
+      "effect": "Activating this ability at the start of a combat round allows you to retain your initiative card from the previous round instead of drawing a new one. Doing so does not count as an action."
+    }
+  ],
+  "magic_as_heroic_ability": {
+    "description": "Mages wield magic instead of a typical heroic ability.",
+    "cost_wp": "Varies (see Spells)",
+    "effect": "As a wizard you can use magic. Read more about magic on page 23 in the Quickstart PDF."
+  }
+}

--- a/dragonbane-char-gen/src/data/kin.json
+++ b/dragonbane-char-gen/src/data/kin.json
@@ -1,0 +1,55 @@
+[
+  {
+    "name": "Human",
+    "innate_ability": null,
+    "description": "Humans are one of the playable kin."
+  },
+  {
+    "name": "Halfling",
+    "innate_ability": {
+      "name": "Hard to Catch",
+      "cost_wp": 3,
+      "effect": "You can activate this ability when dodging an attack, getting a boon to the EVADE roll."
+    },
+    "description": "Halflings are one of the playable kin. Krisanna the Bold is a Halfling Thief."
+  },
+  {
+    "name": "Dwarf",
+    "innate_ability": null,
+    "description": "Dwarfs are one of the playable kin."
+  },
+  {
+    "name": "Elf",
+    "innate_ability": {
+      "name": "Inner Peace",
+      "cost_wp": "—",
+      "effect": "As an elf, you can meditate deeply during a stretch rest. You heal an additional D6 HP and a D6 extra WP, and can recover from an additional condition. You are completely unresponsive during your meditation and cannot be awakened."
+    },
+    "description": "Elves are one of the playable kin. Orla Moonsilver is an Elf Hunter."
+  },
+  {
+    "name": "Mallard",
+    "innate_abilities": [
+      {
+        "name": "Ill-tempered",
+        "cost_wp": 3,
+        "effect": "Mallards tend to have a choleric temper. You can activate this ability (no action) when making a skill roll and get a boon to the roll. You also become Angry, if you’re not already. This ability cannot be used for rolls against INT or INT-based skills."
+      },
+      {
+        "name": "Webbed Feet",
+        "cost_wp": "—",
+        "effect": "As a mallard you also get a boon to all SWIMMING rolls. You always move at full speed in or under water."
+      }
+    ],
+    "description": "Mallards are one of the playable kin and have two innate abilities. Makander of Halfbay is a Mallard Knight."
+  },
+  {
+    "name": "Wolfkin",
+    "innate_ability": {
+      "name": "Hunting Instincts",
+      "cost_wp": 3,
+      "effect": "You can use this ability to designate a creature in sight, or a creature you can catch the scent of, as your prey. This counts as an action in combat. You can follow the scent of your prey for a full day, and you can spend 1 further WP (not an action) to gain a boon for an attack against your prey."
+    },
+    "description": "Wolfkin are one of the playable kin. Bastonn Bloodjaw is a Wolfkin Fighter."
+  }
+]

--- a/dragonbane-char-gen/src/data/mementos.json
+++ b/dragonbane-char-gen/src/data/mementos.json
@@ -1,0 +1,25 @@
+{
+  "rule": "An item of great sentimental value that you always carry with you. Always a tiny item with no practical use. Once per gaming session, you can use your memento to recover an additional condition during a stretch rest.",
+  "examples": [
+    {
+      "name": "Worn diary full of your experiences and discoveries.",
+      "character_example": "Archmaster Aodhan"
+    },
+    {
+      "name": "Fang from the troll that slew your sister.",
+      "character_example": "Orla Moonsilver"
+    },
+    {
+      "name": "A fine pipe made of black horn (a gift from your father).",
+      "character_example": "Makander of Halfbay"
+    },
+    {
+      "name": "A treasure map you \"found.\"",
+      "character_example": "Krisanna the Bold"
+    },
+    {
+      "name": "Blue bottle of perfume.",
+      "character_example": "Bastonn Bloodjaw"
+    }
+  ]
+}

--- a/dragonbane-char-gen/src/data/professions.json
+++ b/dragonbane-char-gen/src/data/professions.json
@@ -1,0 +1,25 @@
+{
+  "note": "Professions are described in detail in the full Dragonbane core game. The Quickstart PDF mentions the following professions for the pre-generated characters, but does not provide a comprehensive list or mechanics for profession selection beyond this.",
+  "examples_from_pregen": [
+    {
+      "name": "Mage - Elementalist",
+      "character": "Archmaster Aodhan"
+    },
+    {
+      "name": "Hunter",
+      "character": "Orla Moonsilver"
+    },
+    {
+      "name": "Knight",
+      "character": "Makander of Halfbay"
+    },
+    {
+      "name": "Thief",
+      "character": "Krisanna the Bold"
+    },
+    {
+      "name": "Fighter",
+      "character": "Bastonn Bloodjaw"
+    }
+  ]
+}

--- a/dragonbane-char-gen/src/data/skills.json
+++ b/dragonbane-char-gen/src/data/skills.json
@@ -1,0 +1,54 @@
+{
+  "note": "The full Dragonbane game describes thirty core skills. This list is derived from the Quickstart Guide and pre-generated characters and may not be exhaustive. The base attribute is included where specified by the pre-gen sheets.",
+  "core_skills": [
+    { "name": "Acrobatics", "attribute": "AGL" },
+    { "name": "Awareness", "attribute": "INT" },
+    { "name": "Bartering", "attribute": "CHA" },
+    { "name": "Beast Lore", "attribute": "INT" },
+    { "name": "Bluffing", "attribute": "CHA" },
+    { "name": "Bushcraft", "attribute": "INT" },
+    { "name": "Crafting", "attribute": "STR" },
+    { "name": "Evade", "attribute": "AGL" },
+    { "name": "Healing", "attribute": "INT" },
+    { "name": "Hunting & Fishing", "attribute": "AGL" },
+    { "name": "Languages", "attribute": "INT" },
+    { "name": "Myths & Legends", "attribute": "INT" },
+    { "name": "Performance", "attribute": "CHA" },
+    { "name": "Persuasion", "attribute": "CHA" },
+    { "name": "Riding", "attribute": "AGL" },
+    { "name": "Seamanship", "attribute": "INT" },
+    { "name": "Sleight of Hand", "attribute": "AGL" },
+    { "name": "Sneaking", "attribute": "AGL" },
+    { "name": "Spot Hidden", "attribute": "INT" },
+    { "name": "Swimming", "attribute": "AGL" }
+  ],
+  "weapon_skills": [
+    { "name": "Axes", "attribute": "STR" },
+    { "name": "Bows", "attribute": "AGL" },
+    { "name": "Brawling", "attribute": "STR" },
+    { "name": "Crossbows", "attribute": "AGL" },
+    { "name": "Hammers", "attribute": "STR" },
+    { "name": "Knives", "attribute": "AGL" },
+    { "name": "Slings", "attribute": "AGL" },
+    { "name": "Spears", "attribute": "STR" },
+    { "name": "Staves", "attribute": "AGL" },
+    { "name": "Swords", "attribute": "STR" }
+  ],
+  "secondary_skills": [
+    { "name": "Elementalism", "attribute": "INT", "description": "A school of magic." },
+    { "name": "Animism", "attribute": null, "description": "A school of magic (mentioned, not detailed in pre-gen)." },
+    { "name": "Mentalism", "attribute": null, "description": "A school of magic (mentioned, not detailed in pre-gen)." }
+  ],
+  "general_skill_rules": {
+    "measurement": "Skill level on a scale from 1 to 18. Higher is better.",
+    "rolling": "Roll a D20. Result <= skill level is a success.",
+    "failure": "Rolling above skill level means failure.",
+    "dragon_roll": "Rolling a 1 (dragon) is a particular success. Combat: specific effects (e.g., increased damage). Outside combat: GM decides (impress, achieve more, faster action).",
+    "demon_roll": "Rolling a 20 (demon) fails regardless of skill level and cannot be pushed. Combat: additional effects. Outside combat: GM decides (damage self/other/item, make fool of self, make noise).",
+    "only_one_chance": "Rule: only one chance to succeed with an action. Does not apply in combat.",
+    "help_from_others": "Declare before roll. Helper must be present and capable. Gives a boon. Helper loses own action in combat. Only one helper per roll.",
+    "boons_banes": "Roll two D20. Boon: best result applies. Bane: worst result applies. Multiple: roll additional D20 for each, count only lowest/highest. Boon negates Bane.",
+    "pushing_roll": "Optional rule. Re-roll failed skill/attribute roll. New result applies. Cannot push a demon roll. Suffer a condition immediately after re-roll (Exhausted-STR, Sickly-CON, Dazed-AGL, Angry-INT, Scared-WIL, Disheartened-CHA). Cannot choose existing condition. Must explain how condition results. GM can reject. Once all six conditions, no more pushing.",
+    "opposed_rolls": "Used when actively opposed. Both roll. Active party only can push. If your roll fails, action fails. If your roll succeeds & opponent fails, action succeeds. If both succeed, your action succeeds if your roll <= opponent's result."
+  }
+}

--- a/dragonbane-char-gen/src/data/spells.json
+++ b/dragonbane-char-gen/src/data/spells.json
@@ -1,0 +1,68 @@
+{
+  "note": "This list contains magic tricks and spells detailed in the Dragonbane Quickstart PDF. The full core game contains more.",
+  "magic_rules": {
+    "casting_cost_wp": "Magic Tricks: 1 WP. Spells: 2 WP per power level (1-3). Spells without power level always cost 2 WP.",
+    "casting_roll": "Roll against skill level in the relevant school. Success = intended effect. Failure = no effect, WP still spent. Can push roll (optional rule). Magic tricks succeed automatically.",
+    "requirements": "Spells may require Word, Gesture, Focus (item held), or Ingredient (consumed). All requirements must be fulfilled.",
+    "casting_time": "Usually an action. Reaction spells exist (do not replace regular action). Rituals take a stretch or shift.",
+    "range": "Max distance. Personal: affects caster only. Area of Effect: starts at mage unless specified; can exempt targets with a bane. Sphere: affects all targets in area except mage. Cone: width equals distance from source, range is length.",
+    "duration": "Instant, Round (until next turn), Stretch, Shift, Concentration (ceases if another action, damage, or failed WIL vs fear; WIL roll to maintain if disturbed).",
+    "failure_dragons_demons": {
+      "failure": "No effect, WP spent. Describe manifest non-mechanically.",
+      "dragon_roll": "Target must roll dragon to resist/parry/dodge. Choose one: double damage/range; spell costs 0 WP; immediately cast another spell with bane.",
+      "demon_roll": "Cannot push roll."
+    }
+  },
+  "magic_tricks": [
+    {
+      "name": "Heat/Chill",
+      "cost_wp": 1,
+      "effect": "The area within 10 meters of you becomes pleasantly warm or cold. The effect protects against cold for one shift of time.",
+      "casting_time": "Action"
+    },
+    {
+      "name": "Ignite",
+      "cost_wp": 1,
+      "effect": "You light or extinguish a candle, torch, or lantern within 10 meters.",
+      "casting_time": "Action"
+    },
+    {
+      "name": "Puff of Smoke",
+      "cost_wp": 1,
+      "effect": "An impressive puff of smoke erupts in front of you. Popular for dramatic entrances, can give boon to SNEAKING (GM discretion).",
+      "casting_time": "Action"
+    }
+  ],
+  "spells": [
+    {
+      "name": "Gust of Wind",
+      "rank": 1,
+      "prerequisite": "Elementalism",
+      "requirement": ["Word", "Gesture"],
+      "casting_time": "Action",
+      "range": "10 meters (cone)",
+      "duration": "Instant",
+      "effect": "All untethered objects and creatures up to human size in the area of effect are pushed 2D4 meters away from you and suffer the same amount of bludgeoning damage. Against a swarm, deals 2D6 damage. Each additional power level increases the number of dice by one."
+    },
+    {
+      "name": "Fireball",
+      "rank": 1,
+      "prerequisite": "Elementalism",
+      "requirement": ["Word", "Gesture"],
+      "casting_time": "Action",
+      "range": "20 meters",
+      "duration": "Instant",
+      "effect": "Sends a fireball from your hand or focus at the target. Can be dodged or parried as a ranged attack. Inflicts 2D6 damage on a hit and sets fire to flammable objects. Each power level beyond the first increases the damage by D6 or creates another fireball that hits another target within range."
+    },
+    {
+      "name": "Pillar",
+      "rank": 1,
+      "prerequisite": "Elementalism",
+      "requirement": ["Word", "Gesture"],
+      "casting_time": "Action",
+      "range": "10 meters",
+      "duration": "Shift",
+      "effect": "Raises a pillar, three meters high and one meter wide, from the ground or a stone floor. If someone is standing in that spot, victim must make an ACROBATICS roll (not an action) to avoid falling off. If pillar is created under a low ceiling and roll fails, victim takes 2D6 bludgeoning damage. For each additional power level, height increases by three meters (can mean falling damage)."
+    }
+  ]
+}

--- a/dragonbane-char-gen/src/data/weaknesses.json
+++ b/dragonbane-char-gen/src/data/weaknesses.json
@@ -1,0 +1,31 @@
+{
+  "note": "Your character has a weakness, an Achilles heel. You can roll or choose from a table in the full game, choose freely, or use these examples from the Quickstart.",
+  "examples": [
+    {
+      "name": "Fainthearted",
+      "description": "You always stay at the back of the group.",
+      "character_example": "Archmaster Aodhan"
+    },
+    {
+      "name": "Bigoted",
+      "description": "Nightkin such as orcs and goblins are evil and need to be fought.",
+      "character_example": "Orla Moonsilver"
+    },
+    {
+      "name": "Foolhardy",
+      "description": "You always go first into danger.",
+      "character_example": "Makander of Halfbay"
+    },
+    {
+      "name": "Reckless",
+      "description": "You always take big risks without thought of the consequences.",
+      "character_example": "Krisanna the Bold"
+    },
+    {
+      "name": "Gluttonous",
+      "description": "You take every chance you get to eat something tasty.",
+      "character_example": "Bastonn Bloodjaw"
+    }
+  ],
+  "generic_weakness_roll_table_reference": "The PDF mentions 'You can roll or choose from the table below or choose your weakness freely'. However, no table is provided in the Quickstart PDF itself, implying it's in the full core game."
+}

--- a/dragonbane-char-gen/src/main.js
+++ b/dragonbane-char-gen/src/main.js
@@ -1,6 +1,11 @@
 import './assets/main.css'
 
 import { createApp } from 'vue'
+import { createPinia } from 'pinia' // Import Pinia
 import App from './App.vue'
 
-createApp(App).mount('#app')
+const app = createApp(App)
+
+app.use(createPinia()) // Use Pinia
+
+app.mount('#app')

--- a/dragonbane-char-gen/src/stores/dragonbaneData.js
+++ b/dragonbane-char-gen/src/stores/dragonbaneData.js
@@ -1,0 +1,49 @@
+import { defineStore } from 'pinia'
+
+// Import all the JSON data files
+import attributesData from '../data/attributes.json'
+import gearData from '../data/gear.json'
+import heroicAbilitiesData from '../data/heroic_abilities.json'
+import kinData from '../data/kin.json'
+import mementosData from '../data/mementos.json'
+import professionsData from '../data/professions.json'
+import skillsData from '../data/skills.json'
+import spellsData from '../data/spells.json'
+import weaknessesData from '../data/weaknesses.json'
+
+export const useDragonbaneDataStore = defineStore('dragonbaneData', {
+  state: () => ({
+    attributes: attributesData,
+    gear: gearData,
+    heroicAbilities: heroicAbilitiesData,
+    kin: kinData,
+    mementos: mementosData,
+    professions: professionsData,
+    skills: skillsData,
+    spells: spellsData,
+    weaknesses: weaknessesData,
+    // You can add more state properties or getters/actions as needed
+  }),
+  // Optional getters
+  getters: {
+    // Example getter: get all kin names
+    allKinNames: (state) => state.kin.map(k => k.name),
+    // Example getter: get a specific skill by name
+    getSkillByName: (state) => (skillName) => {
+      const coreSkill = state.skills.core_skills.find(s => s.name === skillName);
+      if (coreSkill) return coreSkill;
+      const weaponSkill = state.skills.weapon_skills.find(s => s.name === skillName);
+      if (weaponSkill) return weaponSkill;
+      const secondarySkill = state.skills.secondary_skills.find(s => s.name === skillName);
+      return secondarySkill || null;
+    }
+  },
+  // Optional actions
+  actions: {
+    // Example action:
+    // async fetchMoreData() {
+    //   // const response = await fetch('api/more-data')
+    //   // this.someOtherData = await response.json()
+    // }
+  }
+})


### PR DESCRIPTION
- Added Pinia to the project.
- Created JSON files in src/data/ with character generation data extracted from the Quickstart PDF (kin, skills, gear, spells, etc.).
- Created a Pinia store (src/stores/dragonbaneData.js) to load and provide this data.
- Integrated Pinia into the main Vue app setup (main.js).
- Modified App.vue to:
  - Import and use the Pinia store.
  - Log some data from the store on component mount for verification.
  - Populate the 'Kin' selection dropdown from the store's kin data as a demonstration of usage.